### PR TITLE
Fix placeholder splitting

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -151,8 +151,21 @@ export const defaultStrategy: Strategy<HTMLOptions, CleanCSS.Options> = {
     return output.styles;
   },
   splitHTMLByPlaceholder(html, placeholder) {
-    // Make the last character (a semicolon) optional. See above.
-    // return html.split(new RegExp(`${placeholder}?`, 'g'));
-    return html.split(placeholder);
+    // We need to split carefully as minification also removes the semicolon in some cases
+
+    // Suffix explanation:
+    //     (?!   )     negative look-ahead: assert that the contained pattern doesn't match
+    //     (?!\\w)     assert that the next character is not a letter or digit
+    //    ;(?!\\w)     match semicolon only if followed by a non word character
+    // (?:        )    non-capturing group: we don't want to grap parts of the placeholder
+    // (?:;(?!\\w))?   make the whole pattern optional
+    const suffix = '(?:;(?!\\w))?';
+
+    // escape parenthesis and remove the semicolon from the placeholder
+    const escaped = placeholder
+      .replace('(', '\\(')
+      .replace(')', '\\)')
+      .replace(';', '');
+    return html.split(new RegExp(escaped + suffix, 'g'));
   }
 };

--- a/test/minifyHTMLLiterals.spec.ts
+++ b/test/minifyHTMLLiterals.spec.ts
@@ -163,6 +163,54 @@ describe('minifyHTMLLiterals()', () => {
     expect(result!.map!.mappings).to.be.a('string');
   });
 
+  // test for github issue #18
+  const CSS_BLOCK_SOURCE = `
+    const textColor = 'hotpink';
+    const styles = css\`
+      body {
+        /* it is valid to remove the semicolon here if it's the last element of a block */
+        color: \${textColor};
+      }
+    \`;
+  `;
+
+  const CSS_BLOCK_SOURCE_MIN = `
+    const textColor = 'hotpink';
+    const styles = css\`body{color:\${textColor}}\`;
+  `;
+
+  it('should handle css blocks ending with template parts correctly', () => {
+    const result = minifyHTMLLiterals(CSS_BLOCK_SOURCE, {
+      fileName: 'test.js'
+    });
+    expect(result).to.be.an('object');
+    expect(result!.code).to.equal(CSS_BLOCK_SOURCE_MIN);
+  });
+
+  // test for github issue #20
+  const CSS_DROPPED_SEMICOLON_SOURCE = `
+    const fontSize = '12px';
+    const styles = css\`
+      body {
+        font-size: \${fontSize};
+        font-color: #000;
+      }
+    \`;
+  `;
+
+  const CSS_DROPPED_SEMICOLON_SOURCE_MIN = `
+    const fontSize = '12px';
+    const styles = css\`body{font-size:\${fontSize};font-color:#000}\`;
+  `;
+
+  it("shouldn't remove required semicolons", () => {
+    const result = minifyHTMLLiterals(CSS_DROPPED_SEMICOLON_SOURCE, {
+      fileName: 'test.js'
+    });
+    expect(result).to.be.an('object');
+    expect(result!.code).to.equal(CSS_DROPPED_SEMICOLON_SOURCE_MIN);
+  });
+
   describe('options', () => {
     let minifyHTMLSpy: SinonSpy;
 


### PR DESCRIPTION
Update splitting by not just simply using the placeholder itself but by making it context aware:
- Handle cases where the trailing semicolon is removed
- Handle cases where minification merged a required semicolon with the one from the placeholder

Fixes #18 and #20