### PR TITLE
Minify multiline svg

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -124,10 +124,15 @@ export const defaultStrategy: Strategy<HTMLOptions, CleanCSS.Options> = {
       minifyCSSOptions = adjustMinifyCSSOptions(minifyCSSOptions);
     }
 
-    return minify(html, {
+    let str = minify(html, {
       ...options,
       minifyCSS: minifyCSSOptions
     });
+    // Remove any left-over line-breaks including indentation (leaving one space just to be sure)
+    // Example: Minify breaking attribute values such as very long SVG paths
+    // Inspired by: https://github.com/angular/material2/blob/master/tools/package-tools/inline-resources.ts#L55
+    str = str.replace(/[\n\r]\s*/gm, ' ');
+    return str;
   },
   minifyCSS(css, options = {}) {
     const output = new CleanCSS(adjustMinifyCSSOptions(options)).minify(css);

--- a/test/minifyHTMLLiterals.spec.ts
+++ b/test/minifyHTMLLiterals.spec.ts
@@ -142,6 +142,8 @@ describe('minifyHTMLLiterals()', () => {
       return svg\`
         <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
           <path d="M6 19h12v2H6z" />
+          <path d="M150 0 L75 200
+                   L225 200 Z" />
           <path d="M0 0h24v24H0V0z" fill="none" />
         </svg>
       \`;
@@ -150,7 +152,7 @@ describe('minifyHTMLLiterals()', () => {
 
   const SVG_SOURCE_MIN = `
     function taggedSVGMinify() {
-      return svg\`<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M6 19h12v2H6z"/><path d="M0 0h24v24H0V0z" fill="none"/></svg>\`;
+      return svg\`<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M6 19h12v2H6z"/><path d="M150 0 L75 200 L225 200 Z"/><path d="M0 0h24v24H0V0z" fill="none"/></svg>\`;
     }
   `;
 


### PR DESCRIPTION
I'm using this module and have an issue with minifying SVG attributes that contain new lines.

The SVG specification says that newlines behave the same as spaces.

I found an upstream issue ( https://github.com/kangax/html-minifier/issues/865 ) about it not being supported yet.

Then I found a solution in a different package ( https://github.com/dominique-mueller/angular-package-builder/issues/146 ) which seems to work pretty well and I applied it here to this project.