### PR TITLE
Add test for nested template literals

### DIFF
--- a/test/minifyHTMLLiterals.spec.ts
+++ b/test/minifyHTMLLiterals.spec.ts
@@ -214,7 +214,7 @@ describe('minifyHTMLLiterals()', () => {
     }
   `;
 
-  const NESTED_TEMPLATE_SOURCE = `
+  const MEMBER_EXPRESSION_LITERAL_SOURCE = `
     function nested() {
       return LitHtml.html\`<div id="container">
         <span>Some content here</span>
@@ -223,7 +223,7 @@ describe('minifyHTMLLiterals()', () => {
     }
   `;
 
-  const NESTED_TEMPLATE_SOURCE_MIN = `
+  const MEMBER_EXPRESSION_LITERAL_SOURCE_MIN = `
     function nested() {
       return LitHtml.html\`<div id="container"><span>Some content here</span></div>\`;
     }
@@ -248,11 +248,11 @@ describe('minifyHTMLLiterals()', () => {
   });
 
   it('should minify html tagged with a member expression ending in html', () => {
-    const result = minifyHTMLLiterals(NESTED_TEMPLATE_SOURCE, {
+    const result = minifyHTMLLiterals(MEMBER_EXPRESSION_LITERAL_SOURCE, {
       fileName: 'test.js'
     });
     expect(result).to.be.an('object');
-    expect(result!.code).to.equal(NESTED_TEMPLATE_SOURCE_MIN);
+    expect(result!.code).to.equal(MEMBER_EXPRESSION_LITERAL_SOURCE_MIN);
   });
 
   it('should minify multiline svg elements', () => {

--- a/test/minifyHTMLLiterals.spec.ts
+++ b/test/minifyHTMLLiterals.spec.ts
@@ -214,6 +214,21 @@ describe('minifyHTMLLiterals()', () => {
     }
   `;
 
+  const NESTED_TEMPLATE_SOURCE = `
+    function nested() {
+      return LitHtml.html\`<div id="container">
+        <span>Some content here</span>
+      </div>
+      \`;
+    }
+  `;
+
+  const NESTED_TEMPLATE_SOURCE_MIN = `
+    function nested() {
+      return LitHtml.html\`<div id="container"><span>Some content here</span></div>\`;
+    }
+  `;
+
   it('should minify "html" and "css" tagged templates', () => {
     const result = minifyHTMLLiterals(SOURCE, { fileName: 'test.js' });
     expect(result).to.be.an('object');
@@ -230,6 +245,14 @@ describe('minifyHTMLLiterals()', () => {
     const result = minifyHTMLLiterals(COMMENT_SOURCE, { fileName: 'test.js' });
     expect(result).to.be.an('object');
     expect(result!.code).to.equal(COMMENT_SOURCE_MIN);
+  });
+
+  it('should minify html tagged with a member expression ending in html', () => {
+    const result = minifyHTMLLiterals(NESTED_TEMPLATE_SOURCE, {
+      fileName: 'test.js'
+    });
+    expect(result).to.be.an('object');
+    expect(result!.code).to.equal(NESTED_TEMPLATE_SOURCE_MIN);
   });
 
   it('should minify multiline svg elements', () => {


### PR DESCRIPTION
Initially I thought this package wouldn't work for nested template
literals (which ChromeDevTools used). I wanted to do TDD and add
the test first (since there was no test for it yet) and I discovered
this use case is already covered. That's because the `template.tag`
for MemberExpressions already includes the whole line, and thus
it matches on `lihtml.html`, which indeed includes `html`.

So let's add the test to make sure this use case remains covers,
but no actual code changes are required :tada: